### PR TITLE
Validation filter updates

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,19 +35,22 @@ jobs:
       run: echo "BUILD_NUMBER=$NOW.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore /p:BuildNumber=$BUILD_NUMBER /p:SourceRevisionId=$GITHUB_SHA /p:ContinuousIntegrationBuild=true
+      run: dotnet build --configuration Release --no-restore
 
     - name: Test
       run: dotnet test --verbosity normal
 
-    - name: Pack
-      run: dotnet pack --no-build --configuration Release --output finalpackage --verbosity d /p:BuildNumber=$BUILD_NUMBER /p:SourceRevisionId=$GITHUB_SHA /p:ContinuousIntegrationBuild=true
+    - name: Pack (ci)
+      run: dotnet pack --configuration Release --output artifacts/ci --verbosity d -p:BuildNumber=$BUILD_NUMBER -p:SourceRevisionId=$GITHUB_SHA -p:ContinuousIntegrationBuild=true
+
+    - name: Pack (ship candidate)
+      run: dotnet pack --configuration Release --output artifacts/ship --verbosity d -p:BuildNumber=$BUILD_NUMBER -p:SourceRevisionId=$GITHUB_SHA -p:ContinuousIntegrationBuild=true -p:IsShipCandidate=true
 
     - name: Publish artifact
       uses: actions/upload-artifact@master
       with:
         name: nupkg
-        path: finalpackage
+        path: artifacts/**/*.nupkg
 
   deploy:
     needs: build
@@ -67,7 +70,7 @@ jobs:
         run: dotnet nuget add source --username ${{ secrets.GPR_USERNAME }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name GPR ${{ secrets.GPR_URI }}
 
       - name: Push to GitHub Packages
-        run: dotnet nuget push **/*.nupkg -s "GPR" --skip-duplicate
+        run: dotnet nuget push **/ci/*.nupkg -s "GPR" --skip-duplicate
 
   clean:
     needs: deploy

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,13 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.1</VersionPrefix>
-    <VersionSuffix Condition="'$(BuildNumber)' == ''">pre</VersionSuffix>
-    <VersionSuffix Condition="'$(BuildNumber)' != ''">pre.$(BuildNumber)</VersionSuffix>
+    <VersionPrefix>0.10.0</VersionPrefix>
+    <!-- VersionSuffix used for local builds -->
+    <VersionSuffix>dev</VersionSuffix>
+    <!-- VersionSuffix to be used for CI builds -->
+    <VersionSuffix Condition=" '$(ContinuousIntegrationBuild)' == 'true' And '$(BuildNumber)' != '' ">ci.$(BuildNumber)</VersionSuffix>
+    <VersionSuffix Condition=" '$(ContinuousIntegrationBuild)' == 'true' And '$(IsShipCandidate)' == 'true' "></VersionSuffix>
+    <!--<VersionSuffix Condition=" '$(ContinuousIntegrationBuild)' == 'true' And '$(IsShipCandidate)' == 'true' ">pre.$(BuildNumber)</VersionSuffix>-->
     <Authors>Damian Edwards</Authors>
     <Copyright>Copyright © Damian Edwards</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/MinimalApis.Extensions/Filters/ValidateAttribute.cs
+++ b/src/MinimalApis.Extensions/Filters/ValidateAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace MinimalApis.Extensions.Filters;
+
+/// <summary>
+/// Indicates a route handler delegate parameter should be validated before the route handler is invoked.
+/// </summary>
+/// <remarks>
+/// Should be used in conjunction with <see cref="ValidationFilterRouteHandlerBuilderExtensions.WithParameterValidation{TBuilder}(TBuilder, bool, int)"/>
+/// to enable route handler delegate parameter validation.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class ValidateAttribute : Attribute
+{
+
+}

--- a/src/MinimalApis.Extensions/MinimalApis.Extensions.csproj
+++ b/src/MinimalApis.Extensions/MinimalApis.Extensions.csproj
@@ -18,7 +18,7 @@
     <None Include="../../README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MiniValidation" Version="0.6.0-pre.20220527.55" />
+    <PackageReference Include="MiniValidation" Version="0.7.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/TodosApis.Dapper.IntegrationTests/TodosApplication.cs
+++ b/tests/TodosApis.Dapper.IntegrationTests/TodosApplication.cs
@@ -17,7 +17,7 @@ class TodosApplication : WebApplicationFactory<Program>
         {
             services.AddScoped<IDbConnection>(_ => new SqliteConnection("Data Source=todos-default.db;Cache=Shared"));
 
-            TodosApplication.EnsureDbRecreated(services).Wait();
+            EnsureDbRecreated(services).Wait();
         });
 
         return base.CreateHost(builder);
@@ -29,7 +29,7 @@ class TodosApplication : WebApplicationFactory<Program>
 
         using var db = serviceProvider.CreateScope().ServiceProvider.GetRequiredService<IDbConnection>();
 
-        await TodosApplication.EnsureTableDeleted(db);
+        await EnsureTableDeleted(db);
         await EnsureTableCreated(db);
     }
 


### PR DESCRIPTION
- Validation filter updated for latest MiniValidation (0.7.0)
- Made async
- Don't box all parameters on every request by only getting parameter values if we're going to validate them
- Added support for filter mode where parameters must be opted in to validation via a new [Validate] attribute
- Updated CI to produce ship candidate packages & dropped the pre-release suffix
 
Fixes #40
Partially addresses #39
Fixes #37