### PR TITLE
Provide services to validation in the validation filter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.4.3" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
-    <PackageVersion Include="MiniValidation" Version="0.7.2" />
+    <PackageVersion Include="MiniValidation" Version="0.8.0" />
     <PackageVersion Include="Dapper" Version="2.0.123" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />

--- a/samples/TodosApi.Dapper/AllowedNameProvider.cs
+++ b/samples/TodosApi.Dapper/AllowedNameProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace TodosApi.Dapper;
+
+public class AllowedNameProvider
+{
+    public bool IsAllowed(string name) =>
+        !string.Equals(name, "Todo", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(name, "Title", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(name, "Name", StringComparison.OrdinalIgnoreCase);
+}

--- a/samples/TodosApi.Dapper/Program.cs
+++ b/samples/TodosApi.Dapper/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddScoped<IDbConnection>(_ => new SqliteConnection(connectionSt
 builder.Services.AddEndpointsMetadataProviderApiExplorer();
 #else
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSingleton<AllowedNameProvider>();
 #endif
 builder.Services.AddSwaggerGen(ConfigureSwaggerGen);
 

--- a/samples/TodosApi.Dapper/TodosApi.net7.cs
+++ b/samples/TodosApi.Dapper/TodosApi.net7.cs
@@ -77,12 +77,21 @@ public static class TodosApi
         TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos"));
 }
 
-public class NewTodo
+public class NewTodo : IValidatableObject
 {
     [Required]
     public string? Title { get; set; }
 
     public bool IsComplete { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var nameValidation = validationContext.GetRequiredService<AllowedNameProvider>();
+        if (Title is not null && !nameValidation.IsAllowed(Title))
+        {
+            yield return new($"'{Title}' is not an allowed title.", new[] { nameof(Title) });
+        }
+    }
 
     public static implicit operator Todo(NewTodo todo) => new() { Title = todo.Title, IsComplete = todo.IsComplete };
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.10.1</VersionPrefix>
+    <VersionPrefix>0.11.0</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MinimalApis.Extensions/Filters/ValidationFilterRouteHandlerBuilderExtensions.cs
+++ b/src/MinimalApis.Extensions/Filters/ValidationFilterRouteHandlerBuilderExtensions.cs
@@ -169,7 +169,7 @@ public static class ValidationFilterRouteHandlerBuilderExtensions
                             }
                         }
 
-                        var (isValid, errors) = await MiniValidator.TryValidateAsync(argument, recurse: true);
+                        var (isValid, errors) = await MiniValidator.TryValidateAsync(argument, efic.HttpContext.RequestServices, recurse: true);
 
                         if (!isValid)
                         {

--- a/tests/TodosApis.Dapper.IntegrationTests/TodosApiIntegration.cs
+++ b/tests/TodosApis.Dapper.IntegrationTests/TodosApiIntegration.cs
@@ -91,6 +91,30 @@ public class TodosApiIntegration
         Assert.Empty(todos);
     }
 
+#if NET7_0_OR_GREATER
+    [Fact]
+    public async Task PostTodo_Returns_BadRequest_For_Todo_With_Disallowed_Name()
+    {
+        using var application = new TodosApplication();
+
+        var httpClient = application.CreateClient();
+
+        var newTodo = new NewTodo
+        {
+            Title = "Title"
+        };
+
+        var response = await httpClient.PostAsJsonAsync("/todos", newTodo);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var todos = await httpClient.GetFromJsonAsync<List<Todo>>("/todos");
+
+        Assert.NotNull(todos);
+        Assert.Empty(todos);
+    }
+#endif
+
     [Fact]
     public async Task UpdateTodo_Returns_NoContent_For_Valid_Todo()
     {


### PR DESCRIPTION
- Updated to MiniValidation 0.8.0
- Ensure RequestServices is passed to MiniValidator.TryValidate from the validation filter
- Updated TodosApi.Dapper sample to use services in Todo validation
- Updated integration tests to ensure TodosApi.Dapper correctly validates Todos using services on .NET 7
- Bumped to version 0.11.0