### PR TITLE
Update ProducesResponseTypeMetadata to support .NET 10 Preview 2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,17 +11,20 @@
     <PackageVersion Include="Dapper" Version="2.0.123" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="6.0.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.0-preview.2.25163.8" Condition="'$(TargetFramework)'=='net10.0'" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0-preview-25107-01" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="Moq.Dapper" Version="1.0.4" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" Condition="'$(TargetFramework)'=='net6.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="6.0.11" Condition="'$(TargetFramework)'=='net6.0'" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.36" Condition="'$(TargetFramework)'=='net6.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.20" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-preview.2.25164.1 " Condition="'$(TargetFramework)'=='net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="6.0.36" Condition="'$(TargetFramework)'=='net6.0'" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="7.0.20" Condition="'$(TargetFramework)'=='net7.0'" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.0-preview.2.25164.1" Condition="'$(TargetFramework)'=='net10.0'" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "10.0.100-preview.2.25164.34",
     "rollForward": "feature",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }

--- a/src/MinimalApis.Extensions/Binding/BindOfT.cs
+++ b/src/MinimalApis.Extensions/Binding/BindOfT.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using MinimalApis.Extensions.Metadata;
 
 namespace MinimalApis.Extensions.Binding;
 
@@ -113,8 +112,8 @@ public struct Bind<TValue> : IEndpointParameterMetadataProvider
         }
         else
         {
-            metadata.Add(new AcceptsMetadata(typeof(TValue)));
-        };
+            metadata.Add(new MinimalApis.Extensions.Metadata.AcceptsMetadata(typeof(TValue)));
+        }
     }
 
     private const string Template_ResolvedFromDI = nameof(IParameterBinder<object>) + "<{ParameterBinderTargetTypeName}> resolved from DI container.";

--- a/src/MinimalApis.Extensions/Binding/BodyOfT.cs
+++ b/src/MinimalApis.Extensions/Binding/BodyOfT.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Net.Http.Headers;
-using MinimalApis.Extensions.Metadata;
 
 namespace MinimalApis.Extensions.Binding;
 
@@ -231,7 +230,7 @@ public record struct Body<TBody> : IEndpointParameterMetadataProvider
     {
         if (typeof(TBody) == typeof(string))
         {
-            metadata.Add(new AcceptsMetadata(typeof(string), AcceptsMetadata.TextPlainContentType));
+            metadata.Add(new MinimalApis.Extensions.Metadata.AcceptsMetadata(typeof(string), MinimalApis.Extensions.Metadata.AcceptsMetadata.TextPlainContentType));
         }
     }
 

--- a/src/MinimalApis.Extensions/Binding/JsonFormFile.cs
+++ b/src/MinimalApis.Extensions/Binding/JsonFormFile.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using MinimalApis.Extensions.Metadata;
 
 namespace MinimalApis.Extensions.Binding;
 
@@ -208,7 +207,7 @@ public class JsonFormFile : IEndpointParameterMetadataProvider
 
     private static void PopulateMetadataImpl(ParameterInfo parameter, IList<object> metadata, IServiceProvider services)
     {
-        metadata.Add(new AcceptsMetadata(AcceptsMetadata.MultipartFormContentType));
+        metadata.Add(new MinimalApis.Extensions.Metadata.AcceptsMetadata(Metadata.AcceptsMetadata.MultipartFormContentType));
         // TODO: Ensure this metadata is consumed by EndpointMetadataProviderApiDescriptionProvider to configure the parameter
         //       such that the Swagger UI will render the file upload UI automatically.
         metadata.Add(new Mvc.ApiExplorer.ApiParameterDescription { Name = parameter.Name ?? "file", Source = Mvc.ModelBinding.BindingSource.FormFile });

--- a/src/MinimalApis.Extensions/Metadata/IEndpointParameterMetadataProvider.cs
+++ b/src/MinimalApis.Extensions/Metadata/IEndpointParameterMetadataProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using Microsoft.AspNetCore.Builder;
-using MinimalApis.Extensions.Metadata;
 
 namespace Microsoft.AspNetCore.Http.Metadata;
 
@@ -29,7 +28,7 @@ internal static class EndpointParameterMetadataHelpers
             return;
         }
 
-        metadata.Add(new AcceptsMetadata(typeof(TValue), false, DefaultAcceptsContentTypes));
+        metadata.Add(new MinimalApis.Extensions.Metadata.AcceptsMetadata(typeof(TValue), false, DefaultAcceptsContentTypes));
     }
 
 #if NET7_0_OR_GREATER

--- a/src/MinimalApis.Extensions/Metadata/ProducesResponseTypeMetadata.cs
+++ b/src/MinimalApis.Extensions/Metadata/ProducesResponseTypeMetadata.cs
@@ -64,6 +64,11 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
     /// </summary>
     public int StatusCode { get; set; }
 
+    /// <summary>
+    /// Gets the description of the response.
+    /// </summary>
+    public string? Description { get; set; }
+
     public IEnumerable<string> ContentTypes => _contentTypes;
 
     //internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes) => new(type, statusCode, contentTypes);

--- a/src/MinimalApis.Extensions/MinimalApis.Extensions.csproj
+++ b/src/MinimalApis.Extensions/MinimalApis.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net10.0</TargetFrameworks>
     <Description>A set of extensions and helpers for working with ASP.NET Core Minimal APIs.</Description>
     <PackageTags>ASP.NET Web MinimalApis Apis REST Binding IResult</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/tests/MinimalApis.Extensions.UnitTests/MinimalApis.Extensions.UnitTests.csproj
+++ b/tests/MinimalApis.Extensions.UnitTests/MinimalApis.Extensions.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/TodosApi.Dapper.UnitTests/TodosApi.Dapper.UnitTests.csproj
+++ b/tests/TodosApi.Dapper.UnitTests/TodosApi.Dapper.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/TodosApis.Dapper.IntegrationTests/TodosApis.Dapper.IntegrationTests.csproj
+++ b/tests/TodosApis.Dapper.IntegrationTests/TodosApis.Dapper.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I'm not sure if we should add .NET 8 and 9 too or not.
The change for adding the full namespace for `AcceptsMetadata` was because the class was ambiguous.

Also, the tests are passing for .NET 10, but I'm not sure about 6 and 7 and PR doesn't seem to run the tests here.

Fixes #49